### PR TITLE
Specify MIME Recipient Headers

### DIFF
--- a/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMSSQL.sql
@@ -446,9 +446,10 @@ create table hm_fetchaccounts
 	faprocessmimerecipients tinyint not null,
 	faprocessmimedate tinyint not null,
 	faconnectionsecurity tinyint not null,
-   fauseantispam tinyint not null,
-   fauseantivirus tinyint not null,
-   faenablerouterecipients tinyint not null
+	fauseantispam tinyint not null,
+	fauseantivirus tinyint not null,
+	faenablerouterecipients tinyint not null,
+	famimerecipientheaders nvarchar(255) not null DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To'
 ) 
 
 ALTER TABLE hm_fetchaccounts ADD CONSTRAINT hm_fetchaccounts_pk PRIMARY KEY NONCLUSTERED (faid) 
@@ -957,4 +958,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0) 
 
-insert into hm_dbversion values (5703)
+insert into hm_dbversion values (5704)

--- a/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesMYSQL.sql
@@ -310,9 +310,10 @@ create table hm_fetchaccounts
 	faprocessmimerecipients tinyint not null,
 	faprocessmimedate tinyint not null,
 	faconnectionsecurity tinyint not null,
-   fauseantispam tinyint not null,
-   fauseantivirus tinyint not null,
-   faenablerouterecipients tinyint not null
+	fauseantispam tinyint not null,
+	fauseantivirus tinyint not null,
+	faenablerouterecipients tinyint not null,
+	famimerecipientheaders varchar(255) not null DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To'
 ) DEFAULT CHARSET=utf8;
 
 create table hm_fetchaccounts_uids
@@ -782,4 +783,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0);
 
-insert into hm_dbversion values (5703);
+insert into hm_dbversion values (5704);

--- a/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
+++ b/hmailserver/source/DBScripts/CreateTablesPGSQL.sql
@@ -327,7 +327,8 @@ create table hm_fetchaccounts
 	faconnectionsecurity smallint not null,
     fauseantispam smallint not null,
     fauseantivirus smallint not null,
-    faenablerouterecipients smallint not null
+    faenablerouterecipients smallint not null,
+	famimerecipientheaders varchar(255) not null DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To'
 );
 
 create table hm_fetchaccounts_uids
@@ -798,4 +799,4 @@ insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2,
 
 insert into hm_tcpipports (portprotocol, portnumber, portaddress1, portaddress2, portconnectionsecurity, portsslcertificateid) values (5, 143, 0, NULL, 0, 0);
 
-insert into hm_dbversion values (5703);
+insert into hm_dbversion values (5704);

--- a/hmailserver/source/DBScripts/Upgrade5703to5704MSSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5703to5704MSSQL.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `hm_fetchaccounts` ADD COLUMN `famimerecipientheaders` nvarchar(255) NOT NULL DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To'
+
+update hm_dbversion set value = 5704

--- a/hmailserver/source/DBScripts/Upgrade5703to5704MSSQLCE.sql
+++ b/hmailserver/source/DBScripts/Upgrade5703to5704MSSQLCE.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `hm_fetchaccounts` ADD COLUMN `famimerecipientheaders` nvarchar(255) NOT NULL DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To'
+
+update hm_dbversion set value = 5704

--- a/hmailserver/source/DBScripts/Upgrade5703to5704MySQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5703to5704MySQL.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `hm_fetchaccounts` ADD COLUMN `famimerecipientheaders` varchar(255) NOT NULL DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To';
+
+update hm_dbversion set value = 5704

--- a/hmailserver/source/DBScripts/Upgrade5703to5704PGSQL.sql
+++ b/hmailserver/source/DBScripts/Upgrade5703to5704PGSQL.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `hm_fetchaccounts` ADD COLUMN `famimerecipientheaders` varchar(255) NOT NULL DEFAULT 'To,CC,X-RCPT-TO,X-Envelope-To';
+
+update hm_dbversion set value = 5704

--- a/hmailserver/source/Server/COM/InterfaceFetchAccount.cpp
+++ b/hmailserver/source/Server/COM/InterfaceFetchAccount.cpp
@@ -432,6 +432,40 @@ STDMETHODIMP InterfaceFetchAccount::put_ProcessMIMERecipients(VARIANT_BOOL newVa
    }
 }
 
+STDMETHODIMP InterfaceFetchAccount::get_MIMERecipientHeaders(BSTR* pVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      *pVal = object_->GetMIMERecipientHeaders().AllocSysString();
+
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
+STDMETHODIMP InterfaceFetchAccount::put_MIMERecipientHeaders(BSTR newVal)
+{
+   try
+   {
+      if (!object_)
+         return GetAccessDenied();
+
+      object_->SetMIMERecipientHeaders(newVal);
+
+      return S_OK;
+   }
+   catch (...)
+   {
+      return COMError::GenerateGenericMessage();
+   }
+}
+
 STDMETHODIMP InterfaceFetchAccount::get_ProcessMIMEDate(VARIANT_BOOL* pVal)
 {
    try

--- a/hmailserver/source/Server/COM/InterfaceFetchAccount.h
+++ b/hmailserver/source/Server/COM/InterfaceFetchAccount.h
@@ -72,6 +72,8 @@ public:
    STDMETHOD(DownloadNow)(void);
    STDMETHOD(get_ProcessMIMERecipients)(VARIANT_BOOL* pVal);
    STDMETHOD(put_ProcessMIMERecipients)(VARIANT_BOOL newVal);
+   STDMETHOD(get_MIMERecipientHeaders)(BSTR* pVal);
+   STDMETHOD(put_MIMERecipientHeaders)(BSTR newVal);
    STDMETHOD(get_ProcessMIMEDate)(VARIANT_BOOL* pVal);
    STDMETHOD(put_ProcessMIMEDate)(VARIANT_BOOL newVal);
    STDMETHOD(get_UseSSL)(/*[out, retval]*/ VARIANT_BOOL *pVal);

--- a/hmailserver/source/Server/Common/Application/Constants.h
+++ b/hmailserver/source/Server/Common/Application/Constants.h
@@ -136,4 +136,4 @@
 
 #define PROPERTY_IPV6_PREFERRED  _T("IPv6Preferred")
 
-#define REQUIRED_DB_VERSION            5703
+#define REQUIRED_DB_VERSION            5704

--- a/hmailserver/source/Server/Common/BO/FetchAccount.cpp
+++ b/hmailserver/source/Server/Common/BO/FetchAccount.cpp
@@ -66,6 +66,7 @@ namespace HM
       pNode->AppendAttr(_T("DaysToKeep"), StringParser::IntToString(days_to_keep_));
       pNode->AppendAttr(_T("Active"), is_active_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("ProcessMIMERecipients"), process_mimerecipients_ ? _T("1") : _T("0"));
+      pNode->AppendAttr(_T("MIMERecipientHeaders"), mime_recipient_headers_);
       pNode->AppendAttr(_T("ProcessMIMEDate"), process_mimedate_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("UseAntiSpam"), use_anti_spam_ ? _T("1") : _T("0"));
       pNode->AppendAttr(_T("UseAntiVirus"), use_anti_virus_ ? _T("1") : _T("0"));
@@ -91,6 +92,7 @@ namespace HM
       days_to_keep_ = _ttoi(pNode->GetAttrValue(_T("DaysToKeep")));
       is_active_ = (pNode->GetAttrValue(_T("Active")) == _T("1"));
       process_mimerecipients_ = (pNode->GetAttrValue(_T("ProcessMIMERecipients")) == _T("1"));
+      mime_recipient_headers_ = pNode->GetAttrValue(_T("MIMERecipientHeaders"));
       process_mimedate_ = (pNode->GetAttrValue(_T("ProcessMIMEDate")) == _T("1"));
       use_anti_spam_ = (pNode->GetAttrValue(_T("UseAntiSpam")) == _T("1"));
       use_anti_virus_ = (pNode->GetAttrValue(_T("UseAntiVirus")) == _T("1"));

--- a/hmailserver/source/Server/Common/BO/FetchAccount.h
+++ b/hmailserver/source/Server/Common/BO/FetchAccount.h
@@ -56,6 +56,9 @@ namespace HM
       bool GetProcessMIMERecipients() const {return process_mimerecipients_; }
       void SetProcessMIMERecipients(bool bNewVal) {process_mimerecipients_ = bNewVal; }
 
+      void SetMIMERecipientHeaders(const String &sNewVal) { mime_recipient_headers_ = sNewVal; }
+      String GetMIMERecipientHeaders() const { return mime_recipient_headers_; }
+
       bool GetProcessMIMEDate() const {return process_mimedate_; }
       void SetProcessMIMEDate(bool bNewVal) {process_mimedate_ = bNewVal; }
 
@@ -97,6 +100,7 @@ namespace HM
       std::shared_ptr<FetchAccountUIDs> uids_;
 
       bool process_mimerecipients_;
+      String mime_recipient_headers_;
       bool process_mimedate_;
 
       bool use_anti_spam_;

--- a/hmailserver/source/Server/Common/Persistence/PersistentFetchAccount.cpp
+++ b/hmailserver/source/Server/Common/Persistence/PersistentFetchAccount.cpp
@@ -101,6 +101,7 @@ namespace HM
       oFA->SetMinutesBetweenTry(pRS->GetLongValue("faminutes"));
       oFA->SetDaysToKeep(pRS->GetLongValue("fadaystokeep"));
       oFA->SetProcessMIMERecipients(pRS->GetLongValue("faprocessmimerecipients") == 1);
+      oFA->SetMIMERecipientHeaders(pRS->GetStringValue("famimerecipientheaders"));
       oFA->SetProcessMIMEDate(pRS->GetLongValue("faprocessmimedate") == 1);
       oFA->SetConnectionSecurity((ConnectionSecurity) pRS->GetLongValue("faconnectionsecurity"));
       oFA->SetNextTry(pRS->GetStringValue("fanexttry"));
@@ -166,6 +167,7 @@ namespace HM
       oStatement.AddColumn("fadaystokeep", pFA->GetDaysToKeep());
       oStatement.AddColumn("fanexttry", Time::GetCurrentDateTime());
       oStatement.AddColumn("faprocessmimerecipients", pFA->GetProcessMIMERecipients());
+      oStatement.AddColumn("famimerecipientheaders", pFA->GetMIMERecipientHeaders());
       oStatement.AddColumn("faprocessmimedate", pFA->GetProcessMIMEDate());
       oStatement.AddColumn("faconnectionsecurity", pFA->GetConnectionSecurity());
       oStatement.AddColumn("fauseantispam", pFA->GetUseAntiSpam());

--- a/hmailserver/source/Server/hMailServer/hMailServer.idl
+++ b/hmailserver/source/Server/hMailServer/hMailServer.idl
@@ -1646,9 +1646,10 @@ interface IInterfaceFetchAccount : IDispatch{
    [propget, id(21), helpstring("Gets or sets whether hMailServer should deliver to recipients in routes.")] HRESULT EnableRouteRecipients([out, retval] VARIANT_BOOL *pVal);
 	[propput, id(21), helpstring("Gets or sets whether hMailServer should deliver to recipients in routes.")] HRESULT EnableRouteRecipients([in] VARIANT_BOOL newVal);
 	[propget, id(22), helpstring("Gets whether the fetch account is currently locked")] HRESULT IsLocked([out, retval] VARIANT_BOOL* pVal);
-   [propget, id(23), helpstring("Connection security for this fetch account.")] HRESULT ConnectionSecurity([out, retval] eConnectionSecurity *pVal);
-   [propput, id(23), helpstring("Connection security for this fetch account.")] HRESULT ConnectionSecurity([in] eConnectionSecurity newVal);
-
+	[propget, id(23), helpstring("Connection security for this fetch account.")] HRESULT ConnectionSecurity([out, retval] eConnectionSecurity *pVal);
+	[propput, id(23), helpstring("Connection security for this fetch account.")] HRESULT ConnectionSecurity([in] eConnectionSecurity newVal);
+	[propget, id(24), helpstring("Read message recipients from these MIME headers.")] HRESULT MIMERecipientHeaders([out, retval] BSTR* pVal);
+	[propput, id(24), helpstring("Read message recipients from these MIME headers.")] HRESULT MIMERecipientHeaders([in] BSTR newVal);
 };
 [
 	object,

--- a/hmailserver/source/Tools/Administrator/Dialogs/formExternalAccount.Designer.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formExternalAccount.Designer.cs
@@ -28,417 +28,441 @@ namespace hMailServer.Administrator.Dialogs
       /// </summary>
       private void InitializeComponent()
       {
-          this.labelName = new System.Windows.Forms.Label();
-          this.labelServerType = new System.Windows.Forms.Label();
-          this.labelPassword = new System.Windows.Forms.Label();
-          this.labelUsername = new System.Windows.Forms.Label();
-          this.labelTCPIPPort = new System.Windows.Forms.Label();
-          this.labelServerAddress = new System.Windows.Forms.Label();
-          this.labelSettings = new System.Windows.Forms.Label();
-          this.labelMinutesBetweenDownload = new System.Windows.Forms.Label();
-          this.labelDays = new System.Windows.Forms.Label();
-          this.groupBox1 = new System.Windows.Forms.GroupBox();
-          this.btnCancel = new System.Windows.Forms.Button();
-          this.btnOK = new System.Windows.Forms.Button();
-          this.buttonDownloadNow = new System.Windows.Forms.Button();
-          this.labelServerInfo = new System.Windows.Forms.Label();
-          this.textPassword = new hMailServer.Administrator.Controls.ucPassword();
-          this.radioNeverDeleteMessages = new hMailServer.Administrator.Controls.ucRadioButton();
-          this.radioDeleteMessagesAfter = new hMailServer.Administrator.Controls.ucRadioButton();
-          this.radioDeleteImmediately = new hMailServer.Administrator.Controls.ucRadioButton();
-          this.checkProcessMIMEDate = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.checkProcessMIMERecipients = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.comboServerType = new hMailServer.Administrator.Controls.ucComboBox();
-          this.checkEnabled = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.checkUseAntiSpam = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.checkUseAntiVirus = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.checkEnableRouteRecipients = new hMailServer.Administrator.Controls.ucCheckbox();
-          this.labelConnectionSecurity = new System.Windows.Forms.Label();
-          this.comboConnectionSecurity = new hMailServer.Administrator.Controls.ucComboBox();
-          this.textDaysToKeepMessages = new hMailServer.Shared.ucText();
-          this.textMinutesBetweenFetch = new hMailServer.Shared.ucText();
-          this.textUsername = new hMailServer.Shared.ucText();
-          this.textPort = new hMailServer.Shared.ucText();
-          this.textServer = new hMailServer.Shared.ucText();
-          this.textName = new hMailServer.Shared.ucText();
-          this.SuspendLayout();
-          // 
-          // labelName
-          // 
-          this.labelName.AutoSize = true;
-          this.labelName.Location = new System.Drawing.Point(8, 8);
-          this.labelName.Name = "labelName";
-          this.labelName.Size = new System.Drawing.Size(35, 13);
-          this.labelName.TabIndex = 17;
-          this.labelName.Text = "Name";
-          // 
-          // labelServerType
-          // 
-          this.labelServerType.AutoSize = true;
-          this.labelServerType.Location = new System.Drawing.Point(19, 101);
-          this.labelServerType.Name = "labelServerType";
-          this.labelServerType.Size = new System.Drawing.Size(31, 13);
-          this.labelServerType.TabIndex = 19;
-          this.labelServerType.Text = "Type";
-          // 
-          // labelPassword
-          // 
-          this.labelPassword.AutoSize = true;
-          this.labelPassword.Location = new System.Drawing.Point(178, 243);
-          this.labelPassword.Name = "labelPassword";
-          this.labelPassword.Size = new System.Drawing.Size(53, 13);
-          this.labelPassword.TabIndex = 37;
-          this.labelPassword.Text = "Password";
-          // 
-          // labelUsername
-          // 
-          this.labelUsername.AutoSize = true;
-          this.labelUsername.Location = new System.Drawing.Point(20, 243);
-          this.labelUsername.Name = "labelUsername";
-          this.labelUsername.Size = new System.Drawing.Size(58, 13);
-          this.labelUsername.TabIndex = 35;
-          this.labelUsername.Text = "User name";
-          // 
-          // labelTCPIPPort
-          // 
-          this.labelTCPIPPort.AutoSize = true;
-          this.labelTCPIPPort.Location = new System.Drawing.Point(176, 152);
-          this.labelTCPIPPort.Name = "labelTCPIPPort";
-          this.labelTCPIPPort.Size = new System.Drawing.Size(64, 13);
-          this.labelTCPIPPort.TabIndex = 33;
-          this.labelTCPIPPort.Text = "TCP/IP port";
-          // 
-          // labelServerAddress
-          // 
-          this.labelServerAddress.AutoSize = true;
-          this.labelServerAddress.Location = new System.Drawing.Point(22, 152);
-          this.labelServerAddress.Name = "labelServerAddress";
-          this.labelServerAddress.Size = new System.Drawing.Size(78, 13);
-          this.labelServerAddress.TabIndex = 31;
-          this.labelServerAddress.Text = "Server address";
-          // 
-          // labelSettings
-          // 
-          this.labelSettings.AutoSize = true;
-          this.labelSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-          this.labelSettings.Location = new System.Drawing.Point(8, 283);
-          this.labelSettings.Name = "labelSettings";
-          this.labelSettings.Size = new System.Drawing.Size(53, 13);
-          this.labelSettings.TabIndex = 40;
-          this.labelSettings.Text = "Settings";
-          // 
-          // labelMinutesBetweenDownload
-          // 
-          this.labelMinutesBetweenDownload.AutoSize = true;
-          this.labelMinutesBetweenDownload.Location = new System.Drawing.Point(24, 304);
-          this.labelMinutesBetweenDownload.Name = "labelMinutesBetweenDownload";
-          this.labelMinutesBetweenDownload.Size = new System.Drawing.Size(137, 13);
-          this.labelMinutesBetweenDownload.TabIndex = 41;
-          this.labelMinutesBetweenDownload.Text = "Minutes between download";
-          // 
-          // labelDays
-          // 
-          this.labelDays.AutoSize = true;
-          this.labelDays.Location = new System.Drawing.Point(319, 493);
-          this.labelDays.Name = "labelDays";
-          this.labelDays.Size = new System.Drawing.Size(29, 13);
-          this.labelDays.TabIndex = 49;
-          this.labelDays.Text = "days";
-          // 
-          // groupBox1
-          // 
-          this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
-                      | System.Windows.Forms.AnchorStyles.Right)));
-          this.groupBox1.Location = new System.Drawing.Point(15, 545);
-          this.groupBox1.Name = "groupBox1";
-          this.groupBox1.Size = new System.Drawing.Size(361, 4);
-          this.groupBox1.TabIndex = 55;
-          this.groupBox1.TabStop = false;
-          // 
-          // btnCancel
-          // 
-          this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-          this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-          this.btnCancel.Location = new System.Drawing.Point(286, 555);
-          this.btnCancel.Name = "btnCancel";
-          this.btnCancel.Size = new System.Drawing.Size(89, 25);
-          this.btnCancel.TabIndex = 54;
-          this.btnCancel.Text = "&Cancel";
-          this.btnCancel.UseVisualStyleBackColor = true;
-          // 
-          // btnOK
-          // 
-          this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-          this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-          this.btnOK.Location = new System.Drawing.Point(191, 555);
-          this.btnOK.Name = "btnOK";
-          this.btnOK.Size = new System.Drawing.Size(89, 25);
-          this.btnOK.TabIndex = 53;
-          this.btnOK.Text = "&OK";
-          this.btnOK.UseVisualStyleBackColor = true;
-          // 
-          // buttonDownloadNow
-          // 
-          this.buttonDownloadNow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-          this.buttonDownloadNow.Location = new System.Drawing.Point(36, 555);
-          this.buttonDownloadNow.Name = "buttonDownloadNow";
-          this.buttonDownloadNow.Size = new System.Drawing.Size(116, 25);
-          this.buttonDownloadNow.TabIndex = 56;
-          this.buttonDownloadNow.Text = "Download now";
-          this.buttonDownloadNow.UseVisualStyleBackColor = true;
-          this.buttonDownloadNow.Click += new System.EventHandler(this.buttonDownloadNow_Click);
-          // 
-          // labelServerInfo
-          // 
-          this.labelServerInfo.AutoSize = true;
-          this.labelServerInfo.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-          this.labelServerInfo.Location = new System.Drawing.Point(8, 80);
-          this.labelServerInfo.Name = "labelServerInfo";
-          this.labelServerInfo.Size = new System.Drawing.Size(110, 13);
-          this.labelServerInfo.TabIndex = 15;
-          this.labelServerInfo.Text = "Server information";
-          // 
-          // textPassword
-          // 
-          this.textPassword.Location = new System.Drawing.Point(179, 259);
-          this.textPassword.Name = "textPassword";
-          this.textPassword.Size = new System.Drawing.Size(128, 20);
-          this.textPassword.TabIndex = 57;
-          this.textPassword.Text = "<< Encrypted >>";
-          // 
-          // radioNeverDeleteMessages
-          // 
-          this.radioNeverDeleteMessages.AutoSize = true;
-          this.radioNeverDeleteMessages.Checked = true;
-          this.radioNeverDeleteMessages.Location = new System.Drawing.Point(21, 514);
-          this.radioNeverDeleteMessages.Name = "radioNeverDeleteMessages";
-          this.radioNeverDeleteMessages.Size = new System.Drawing.Size(139, 17);
-          this.radioNeverDeleteMessages.TabIndex = 47;
-          this.radioNeverDeleteMessages.TabStop = true;
-          this.radioNeverDeleteMessages.Text = "Do not delete messages";
-          this.radioNeverDeleteMessages.UseVisualStyleBackColor = true;
-          // 
-          // radioDeleteMessagesAfter
-          // 
-          this.radioDeleteMessagesAfter.AutoSize = true;
-          this.radioDeleteMessagesAfter.Location = new System.Drawing.Point(21, 491);
-          this.radioDeleteMessagesAfter.Name = "radioDeleteMessagesAfter";
-          this.radioDeleteMessagesAfter.Size = new System.Drawing.Size(130, 17);
-          this.radioDeleteMessagesAfter.TabIndex = 46;
-          this.radioDeleteMessagesAfter.Text = "Delete messages after";
-          this.radioDeleteMessagesAfter.UseVisualStyleBackColor = true;
-          // 
-          // radioDeleteImmediately
-          // 
-          this.radioDeleteImmediately.AutoSize = true;
-          this.radioDeleteImmediately.Location = new System.Drawing.Point(21, 468);
-          this.radioDeleteImmediately.Name = "radioDeleteImmediately";
-          this.radioDeleteImmediately.Size = new System.Drawing.Size(163, 17);
-          this.radioDeleteImmediately.TabIndex = 45;
-          this.radioDeleteImmediately.Text = "Delete messages immediately";
-          this.radioDeleteImmediately.UseVisualStyleBackColor = true;
-          // 
-          // checkProcessMIMEDate
-          // 
-          this.checkProcessMIMEDate.AutoSize = true;
-          this.checkProcessMIMEDate.Location = new System.Drawing.Point(24, 395);
-          this.checkProcessMIMEDate.Name = "checkProcessMIMEDate";
-          this.checkProcessMIMEDate.Size = new System.Drawing.Size(198, 17);
-          this.checkProcessMIMEDate.TabIndex = 44;
-          this.checkProcessMIMEDate.Text = "Retrieve date from Received header";
-          this.checkProcessMIMEDate.UseVisualStyleBackColor = true;
-          this.checkProcessMIMEDate.CheckedChanged += new System.EventHandler(this.checkProcessMIMEDate_CheckedChanged);
-          // 
-          // checkProcessMIMERecipients
-          // 
-          this.checkProcessMIMERecipients.AutoSize = true;
-          this.checkProcessMIMERecipients.Location = new System.Drawing.Point(24, 349);
-          this.checkProcessMIMERecipients.Name = "checkProcessMIMERecipients";
-          this.checkProcessMIMERecipients.Size = new System.Drawing.Size(202, 17);
-          this.checkProcessMIMERecipients.TabIndex = 43;
-          this.checkProcessMIMERecipients.Text = "Deliver to recipients in MIME headers";
-          this.checkProcessMIMERecipients.UseVisualStyleBackColor = true;
-          this.checkProcessMIMERecipients.CheckedChanged += new System.EventHandler(this.checkProcessMIMERecipients_CheckedChanged);
-          // 
-          // comboServerType
-          // 
-          this.comboServerType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-          this.comboServerType.FormattingEnabled = true;
-          this.comboServerType.Location = new System.Drawing.Point(24, 120);
-          this.comboServerType.Name = "comboServerType";
-          this.comboServerType.Size = new System.Drawing.Size(146, 21);
-          this.comboServerType.TabIndex = 20;
-          // 
-          // checkEnabled
-          // 
-          this.checkEnabled.AutoSize = true;
-          this.checkEnabled.Location = new System.Drawing.Point(8, 50);
-          this.checkEnabled.Name = "checkEnabled";
-          this.checkEnabled.Size = new System.Drawing.Size(65, 17);
-          this.checkEnabled.TabIndex = 14;
-          this.checkEnabled.Text = "Enabled";
-          this.checkEnabled.UseVisualStyleBackColor = true;
-          // 
-          // checkUseAntiSpam
-          // 
-          this.checkUseAntiSpam.AutoSize = true;
-          this.checkUseAntiSpam.Location = new System.Drawing.Point(23, 418);
-          this.checkUseAntiSpam.Name = "checkUseAntiSpam";
-          this.checkUseAntiSpam.Size = new System.Drawing.Size(72, 17);
-          this.checkUseAntiSpam.TabIndex = 59;
-          this.checkUseAntiSpam.Text = "Anti-spam";
-          this.checkUseAntiSpam.UseVisualStyleBackColor = true;
-          // 
-          // checkUseAntiVirus
-          // 
-          this.checkUseAntiVirus.AutoSize = true;
-          this.checkUseAntiVirus.Location = new System.Drawing.Point(24, 441);
-          this.checkUseAntiVirus.Name = "checkUseAntiVirus";
-          this.checkUseAntiVirus.Size = new System.Drawing.Size(69, 17);
-          this.checkUseAntiVirus.TabIndex = 58;
-          this.checkUseAntiVirus.Text = "Anti-virus";
-          this.checkUseAntiVirus.UseVisualStyleBackColor = true;
-          // 
-          // checkEnableRouteRecipients
-          // 
-          this.checkEnableRouteRecipients.AutoSize = true;
-          this.checkEnableRouteRecipients.Location = new System.Drawing.Point(45, 372);
-          this.checkEnableRouteRecipients.Name = "checkEnableRouteRecipients";
-          this.checkEnableRouteRecipients.Size = new System.Drawing.Size(126, 17);
-          this.checkEnableRouteRecipients.TabIndex = 60;
-          this.checkEnableRouteRecipients.Text = "Allow route recipients";
-          this.checkEnableRouteRecipients.UseVisualStyleBackColor = true;
-          // 
-          // labelConnectionSecurity
-          // 
-          this.labelConnectionSecurity.AutoSize = true;
-          this.labelConnectionSecurity.Location = new System.Drawing.Point(22, 200);
-          this.labelConnectionSecurity.Name = "labelConnectionSecurity";
-          this.labelConnectionSecurity.Size = new System.Drawing.Size(100, 13);
-          this.labelConnectionSecurity.TabIndex = 62;
-          this.labelConnectionSecurity.Text = "Connection security";
-          // 
-          // comboConnectionSecurity
-          // 
-          this.comboConnectionSecurity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-          this.comboConnectionSecurity.FormattingEnabled = true;
-          this.comboConnectionSecurity.Location = new System.Drawing.Point(24, 216);
-          this.comboConnectionSecurity.Name = "comboConnectionSecurity";
-          this.comboConnectionSecurity.Size = new System.Drawing.Size(171, 21);
-          this.comboConnectionSecurity.TabIndex = 61;
-          this.comboConnectionSecurity.SelectedIndexChanged += new System.EventHandler(this.comboConnectionSecurity_SelectedIndexChanged);
-          // 
-          // textDaysToKeepMessages
-          // 
-          this.textDaysToKeepMessages.Location = new System.Drawing.Point(224, 490);
-          this.textDaysToKeepMessages.Name = "textDaysToKeepMessages";
-          this.textDaysToKeepMessages.Number = 7;
-          this.textDaysToKeepMessages.Number64 = ((long)(7));
-          this.textDaysToKeepMessages.Numeric = true;
-          this.textDaysToKeepMessages.Size = new System.Drawing.Size(78, 20);
-          this.textDaysToKeepMessages.TabIndex = 48;
-          this.textDaysToKeepMessages.Text = "7";
-          // 
-          // textMinutesBetweenFetch
-          // 
-          this.textMinutesBetweenFetch.Location = new System.Drawing.Point(24, 320);
-          this.textMinutesBetweenFetch.Name = "textMinutesBetweenFetch";
-          this.textMinutesBetweenFetch.Number = 30;
-          this.textMinutesBetweenFetch.Number64 = ((long)(30));
-          this.textMinutesBetweenFetch.Numeric = true;
-          this.textMinutesBetweenFetch.Size = new System.Drawing.Size(146, 20);
-          this.textMinutesBetweenFetch.TabIndex = 42;
-          this.textMinutesBetweenFetch.Text = "30";
-          // 
-          // textUsername
-          // 
-          this.textUsername.Location = new System.Drawing.Point(24, 259);
-          this.textUsername.Name = "textUsername";
-          this.textUsername.Number = 0;
-          this.textUsername.Number64 = ((long)(0));
-          this.textUsername.Numeric = false;
-          this.textUsername.Size = new System.Drawing.Size(148, 20);
-          this.textUsername.TabIndex = 36;
-          // 
-          // textPort
-          // 
-          this.textPort.Location = new System.Drawing.Point(176, 168);
-          this.textPort.Name = "textPort";
-          this.textPort.Number = 0;
-          this.textPort.Number64 = ((long)(0));
-          this.textPort.Numeric = true;
-          this.textPort.Size = new System.Drawing.Size(84, 20);
-          this.textPort.TabIndex = 34;
-          // 
-          // textServer
-          // 
-          this.textServer.Location = new System.Drawing.Point(24, 168);
-          this.textServer.Name = "textServer";
-          this.textServer.Number = 0;
-          this.textServer.Number64 = ((long)(0));
-          this.textServer.Numeric = false;
-          this.textServer.Size = new System.Drawing.Size(146, 20);
-          this.textServer.TabIndex = 32;
-          // 
-          // textName
-          // 
-          this.textName.Location = new System.Drawing.Point(8, 24);
-          this.textName.Name = "textName";
-          this.textName.Number = 0;
-          this.textName.Number64 = ((long)(0));
-          this.textName.Numeric = false;
-          this.textName.Size = new System.Drawing.Size(159, 20);
-          this.textName.TabIndex = 18;
-          // 
-          // formExternalAccount
-          // 
-          this.AcceptButton = this.btnOK;
-          this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-          this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-          this.CancelButton = this.btnCancel;
-          this.ClientSize = new System.Drawing.Size(390, 592);
-          this.Controls.Add(this.labelConnectionSecurity);
-          this.Controls.Add(this.comboConnectionSecurity);
-          this.Controls.Add(this.checkEnableRouteRecipients);
-          this.Controls.Add(this.checkUseAntiSpam);
-          this.Controls.Add(this.checkUseAntiVirus);
-          this.Controls.Add(this.textPassword);
-          this.Controls.Add(this.buttonDownloadNow);
-          this.Controls.Add(this.groupBox1);
-          this.Controls.Add(this.btnCancel);
-          this.Controls.Add(this.btnOK);
-          this.Controls.Add(this.labelDays);
-          this.Controls.Add(this.textDaysToKeepMessages);
-          this.Controls.Add(this.radioNeverDeleteMessages);
-          this.Controls.Add(this.radioDeleteMessagesAfter);
-          this.Controls.Add(this.radioDeleteImmediately);
-          this.Controls.Add(this.checkProcessMIMEDate);
-          this.Controls.Add(this.checkProcessMIMERecipients);
-          this.Controls.Add(this.textMinutesBetweenFetch);
-          this.Controls.Add(this.labelMinutesBetweenDownload);
-          this.Controls.Add(this.labelSettings);
-          this.Controls.Add(this.labelPassword);
-          this.Controls.Add(this.textUsername);
-          this.Controls.Add(this.labelUsername);
-          this.Controls.Add(this.textPort);
-          this.Controls.Add(this.labelTCPIPPort);
-          this.Controls.Add(this.textServer);
-          this.Controls.Add(this.labelServerAddress);
-          this.Controls.Add(this.comboServerType);
-          this.Controls.Add(this.labelServerType);
-          this.Controls.Add(this.textName);
-          this.Controls.Add(this.labelName);
-          this.Controls.Add(this.labelServerInfo);
-          this.Controls.Add(this.checkEnabled);
-          this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-          this.MaximizeBox = false;
-          this.MinimizeBox = false;
-          this.Name = "formExternalAccount";
-          this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-          this.Text = "External account";
-          this.Load += new System.EventHandler(this.formExternalAccount_Load);
-          this.ResumeLayout(false);
-          this.PerformLayout();
+         this.labelName = new System.Windows.Forms.Label();
+         this.labelServerType = new System.Windows.Forms.Label();
+         this.labelPassword = new System.Windows.Forms.Label();
+         this.labelUsername = new System.Windows.Forms.Label();
+         this.labelTCPIPPort = new System.Windows.Forms.Label();
+         this.labelServerAddress = new System.Windows.Forms.Label();
+         this.labelSettings = new System.Windows.Forms.Label();
+         this.labelMinutesBetweenDownload = new System.Windows.Forms.Label();
+         this.labelDays = new System.Windows.Forms.Label();
+         this.groupBox1 = new System.Windows.Forms.GroupBox();
+         this.btnCancel = new System.Windows.Forms.Button();
+         this.btnOK = new System.Windows.Forms.Button();
+         this.buttonDownloadNow = new System.Windows.Forms.Button();
+         this.labelServerInfo = new System.Windows.Forms.Label();
+         this.labelConnectionSecurity = new System.Windows.Forms.Label();
+         this.labelMIMERecipientHeaders = new System.Windows.Forms.Label();
+         this.textMIMERecipientHeaders = new hMailServer.Shared.ucText();
+         this.comboConnectionSecurity = new hMailServer.Administrator.Controls.ucComboBox();
+         this.checkEnableRouteRecipients = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.checkUseAntiSpam = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.checkUseAntiVirus = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.textPassword = new hMailServer.Administrator.Controls.ucPassword();
+         this.textDaysToKeepMessages = new hMailServer.Shared.ucText();
+         this.radioNeverDeleteMessages = new hMailServer.Administrator.Controls.ucRadioButton();
+         this.radioDeleteMessagesAfter = new hMailServer.Administrator.Controls.ucRadioButton();
+         this.radioDeleteImmediately = new hMailServer.Administrator.Controls.ucRadioButton();
+         this.checkProcessMIMEDate = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.checkProcessMIMERecipients = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.textMinutesBetweenFetch = new hMailServer.Shared.ucText();
+         this.textUsername = new hMailServer.Shared.ucText();
+         this.textPort = new hMailServer.Shared.ucText();
+         this.textServer = new hMailServer.Shared.ucText();
+         this.comboServerType = new hMailServer.Administrator.Controls.ucComboBox();
+         this.textName = new hMailServer.Shared.ucText();
+         this.checkEnabled = new hMailServer.Administrator.Controls.ucCheckbox();
+         this.SuspendLayout();
+         // 
+         // labelName
+         // 
+         this.labelName.AutoSize = true;
+         this.labelName.Location = new System.Drawing.Point(8, 8);
+         this.labelName.Name = "labelName";
+         this.labelName.Size = new System.Drawing.Size(35, 13);
+         this.labelName.TabIndex = 17;
+         this.labelName.Text = "Name";
+         // 
+         // labelServerType
+         // 
+         this.labelServerType.AutoSize = true;
+         this.labelServerType.Location = new System.Drawing.Point(19, 101);
+         this.labelServerType.Name = "labelServerType";
+         this.labelServerType.Size = new System.Drawing.Size(31, 13);
+         this.labelServerType.TabIndex = 19;
+         this.labelServerType.Text = "Type";
+         // 
+         // labelPassword
+         // 
+         this.labelPassword.AutoSize = true;
+         this.labelPassword.Location = new System.Drawing.Point(178, 243);
+         this.labelPassword.Name = "labelPassword";
+         this.labelPassword.Size = new System.Drawing.Size(53, 13);
+         this.labelPassword.TabIndex = 37;
+         this.labelPassword.Text = "Password";
+         // 
+         // labelUsername
+         // 
+         this.labelUsername.AutoSize = true;
+         this.labelUsername.Location = new System.Drawing.Point(20, 243);
+         this.labelUsername.Name = "labelUsername";
+         this.labelUsername.Size = new System.Drawing.Size(58, 13);
+         this.labelUsername.TabIndex = 35;
+         this.labelUsername.Text = "User name";
+         // 
+         // labelTCPIPPort
+         // 
+         this.labelTCPIPPort.AutoSize = true;
+         this.labelTCPIPPort.Location = new System.Drawing.Point(178, 152);
+         this.labelTCPIPPort.Name = "labelTCPIPPort";
+         this.labelTCPIPPort.Size = new System.Drawing.Size(64, 13);
+         this.labelTCPIPPort.TabIndex = 33;
+         this.labelTCPIPPort.Text = "TCP/IP port";
+         // 
+         // labelServerAddress
+         // 
+         this.labelServerAddress.AutoSize = true;
+         this.labelServerAddress.Location = new System.Drawing.Point(22, 152);
+         this.labelServerAddress.Name = "labelServerAddress";
+         this.labelServerAddress.Size = new System.Drawing.Size(78, 13);
+         this.labelServerAddress.TabIndex = 31;
+         this.labelServerAddress.Text = "Server address";
+         // 
+         // labelSettings
+         // 
+         this.labelSettings.AutoSize = true;
+         this.labelSettings.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+         this.labelSettings.Location = new System.Drawing.Point(8, 283);
+         this.labelSettings.Name = "labelSettings";
+         this.labelSettings.Size = new System.Drawing.Size(53, 13);
+         this.labelSettings.TabIndex = 40;
+         this.labelSettings.Text = "Settings";
+         // 
+         // labelMinutesBetweenDownload
+         // 
+         this.labelMinutesBetweenDownload.AutoSize = true;
+         this.labelMinutesBetweenDownload.Location = new System.Drawing.Point(21, 304);
+         this.labelMinutesBetweenDownload.Name = "labelMinutesBetweenDownload";
+         this.labelMinutesBetweenDownload.Size = new System.Drawing.Size(137, 13);
+         this.labelMinutesBetweenDownload.TabIndex = 41;
+         this.labelMinutesBetweenDownload.Text = "Minutes between download";
+         // 
+         // labelDays
+         // 
+         this.labelDays.AutoSize = true;
+         this.labelDays.Location = new System.Drawing.Point(318, 539);
+         this.labelDays.Name = "labelDays";
+         this.labelDays.Size = new System.Drawing.Size(29, 13);
+         this.labelDays.TabIndex = 49;
+         this.labelDays.Text = "days";
+         // 
+         // groupBox1
+         // 
+         this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+         | System.Windows.Forms.AnchorStyles.Right)));
+         this.groupBox1.Location = new System.Drawing.Point(15, 579);
+         this.groupBox1.Name = "groupBox1";
+         this.groupBox1.Size = new System.Drawing.Size(361, 4);
+         this.groupBox1.TabIndex = 55;
+         this.groupBox1.TabStop = false;
+         // 
+         // btnCancel
+         // 
+         this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+         this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+         this.btnCancel.Location = new System.Drawing.Point(286, 589);
+         this.btnCancel.Name = "btnCancel";
+         this.btnCancel.Size = new System.Drawing.Size(89, 25);
+         this.btnCancel.TabIndex = 54;
+         this.btnCancel.Text = "&Cancel";
+         this.btnCancel.UseVisualStyleBackColor = true;
+         // 
+         // btnOK
+         // 
+         this.btnOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+         this.btnOK.DialogResult = System.Windows.Forms.DialogResult.OK;
+         this.btnOK.Location = new System.Drawing.Point(191, 589);
+         this.btnOK.Name = "btnOK";
+         this.btnOK.Size = new System.Drawing.Size(89, 25);
+         this.btnOK.TabIndex = 53;
+         this.btnOK.Text = "&OK";
+         this.btnOK.UseVisualStyleBackColor = true;
+         // 
+         // buttonDownloadNow
+         // 
+         this.buttonDownloadNow.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+         this.buttonDownloadNow.Location = new System.Drawing.Point(36, 589);
+         this.buttonDownloadNow.Name = "buttonDownloadNow";
+         this.buttonDownloadNow.Size = new System.Drawing.Size(116, 25);
+         this.buttonDownloadNow.TabIndex = 56;
+         this.buttonDownloadNow.Text = "Download now";
+         this.buttonDownloadNow.UseVisualStyleBackColor = true;
+         this.buttonDownloadNow.Click += new System.EventHandler(this.buttonDownloadNow_Click);
+         // 
+         // labelServerInfo
+         // 
+         this.labelServerInfo.AutoSize = true;
+         this.labelServerInfo.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+         this.labelServerInfo.Location = new System.Drawing.Point(8, 80);
+         this.labelServerInfo.Name = "labelServerInfo";
+         this.labelServerInfo.Size = new System.Drawing.Size(110, 13);
+         this.labelServerInfo.TabIndex = 15;
+         this.labelServerInfo.Text = "Server information";
+         // 
+         // labelMIMERecipientHeaders
+         // 
+         this.labelMIMERecipientHeaders.AutoSize = true;
+         this.labelMIMERecipientHeaders.Location = new System.Drawing.Point(20, 349);
+         this.labelMIMERecipientHeaders.Name = "labelMIMERecipientHeaders";
+         this.labelMIMERecipientHeaders.Size = new System.Drawing.Size(119, 13);
+         this.labelMIMERecipientHeaders.TabIndex = 64;
+         this.labelMIMERecipientHeaders.Text = "MIME recipient headers";
+         // 
+         // textMIMERecipientHeaders
+         // 
+         this.textMIMERecipientHeaders.Location = new System.Drawing.Point(23, 366);
+         this.textMIMERecipientHeaders.Name = "textMIMERecipientHeaders";
+         this.textMIMERecipientHeaders.Number = 0;
+         this.textMIMERecipientHeaders.Number64 = ((long)(0));
+         this.textMIMERecipientHeaders.Numeric = false;
+         this.textMIMERecipientHeaders.Size = new System.Drawing.Size(352, 20);
+         this.textMIMERecipientHeaders.TabIndex = 63;
+         this.textMIMERecipientHeaders.TextChanged += new System.EventHandler(this.textMIMERecipientHeaders_TextChanged);
+         // 
+         // labelConnectionSecurity
+         // 
+         this.labelConnectionSecurity.AutoSize = true;
+         this.labelConnectionSecurity.Location = new System.Drawing.Point(22, 200);
+         this.labelConnectionSecurity.Name = "labelConnectionSecurity";
+         this.labelConnectionSecurity.Size = new System.Drawing.Size(100, 13);
+         this.labelConnectionSecurity.TabIndex = 62;
+         this.labelConnectionSecurity.Text = "Connection security";
+         // 
+         // comboConnectionSecurity
+         // 
+         this.comboConnectionSecurity.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+         this.comboConnectionSecurity.FormattingEnabled = true;
+         this.comboConnectionSecurity.Location = new System.Drawing.Point(24, 216);
+         this.comboConnectionSecurity.Name = "comboConnectionSecurity";
+         this.comboConnectionSecurity.Size = new System.Drawing.Size(171, 21);
+         this.comboConnectionSecurity.TabIndex = 61;
+         this.comboConnectionSecurity.SelectedIndexChanged += new System.EventHandler(this.comboConnectionSecurity_SelectedIndexChanged);
+         // 
+         // checkEnableRouteRecipients
+         // 
+         this.checkEnableRouteRecipients.AutoSize = true;
+         this.checkEnableRouteRecipients.Location = new System.Drawing.Point(44, 418);
+         this.checkEnableRouteRecipients.Name = "checkEnableRouteRecipients";
+         this.checkEnableRouteRecipients.Size = new System.Drawing.Size(126, 17);
+         this.checkEnableRouteRecipients.TabIndex = 60;
+         this.checkEnableRouteRecipients.Text = "Allow route recipients";
+         this.checkEnableRouteRecipients.UseVisualStyleBackColor = true;
+         // 
+         // checkUseAntiSpam
+         // 
+         this.checkUseAntiSpam.AutoSize = true;
+         this.checkUseAntiSpam.Location = new System.Drawing.Point(23, 464);
+         this.checkUseAntiSpam.Name = "checkUseAntiSpam";
+         this.checkUseAntiSpam.Size = new System.Drawing.Size(72, 17);
+         this.checkUseAntiSpam.TabIndex = 59;
+         this.checkUseAntiSpam.Text = "Anti-spam";
+         this.checkUseAntiSpam.UseVisualStyleBackColor = true;
+         // 
+         // checkUseAntiVirus
+         // 
+         this.checkUseAntiVirus.AutoSize = true;
+         this.checkUseAntiVirus.Location = new System.Drawing.Point(23, 487);
+         this.checkUseAntiVirus.Name = "checkUseAntiVirus";
+         this.checkUseAntiVirus.Size = new System.Drawing.Size(69, 17);
+         this.checkUseAntiVirus.TabIndex = 58;
+         this.checkUseAntiVirus.Text = "Anti-virus";
+         this.checkUseAntiVirus.UseVisualStyleBackColor = true;
+         // 
+         // textPassword
+         // 
+         this.textPassword.Location = new System.Drawing.Point(180, 259);
+         this.textPassword.Name = "textPassword";
+         this.textPassword.Size = new System.Drawing.Size(128, 20);
+         this.textPassword.TabIndex = 57;
+         this.textPassword.Text = "<< Encrypted >>";
+         // 
+         // textDaysToKeepMessages
+         // 
+         this.textDaysToKeepMessages.Location = new System.Drawing.Point(223, 536);
+         this.textDaysToKeepMessages.Name = "textDaysToKeepMessages";
+         this.textDaysToKeepMessages.Number = 7;
+         this.textDaysToKeepMessages.Number64 = ((long)(7));
+         this.textDaysToKeepMessages.Numeric = true;
+         this.textDaysToKeepMessages.Size = new System.Drawing.Size(78, 20);
+         this.textDaysToKeepMessages.TabIndex = 48;
+         this.textDaysToKeepMessages.Text = "7";
+         // 
+         // radioNeverDeleteMessages
+         // 
+         this.radioNeverDeleteMessages.AutoSize = true;
+         this.radioNeverDeleteMessages.Checked = true;
+         this.radioNeverDeleteMessages.Location = new System.Drawing.Point(22, 560);
+         this.radioNeverDeleteMessages.Name = "radioNeverDeleteMessages";
+         this.radioNeverDeleteMessages.Size = new System.Drawing.Size(139, 17);
+         this.radioNeverDeleteMessages.TabIndex = 47;
+         this.radioNeverDeleteMessages.TabStop = true;
+         this.radioNeverDeleteMessages.Text = "Do not delete messages";
+         this.radioNeverDeleteMessages.UseVisualStyleBackColor = true;
+         // 
+         // radioDeleteMessagesAfter
+         // 
+         this.radioDeleteMessagesAfter.AutoSize = true;
+         this.radioDeleteMessagesAfter.Location = new System.Drawing.Point(22, 537);
+         this.radioDeleteMessagesAfter.Name = "radioDeleteMessagesAfter";
+         this.radioDeleteMessagesAfter.Size = new System.Drawing.Size(130, 17);
+         this.radioDeleteMessagesAfter.TabIndex = 46;
+         this.radioDeleteMessagesAfter.Text = "Delete messages after";
+         this.radioDeleteMessagesAfter.UseVisualStyleBackColor = true;
+         // 
+         // radioDeleteImmediately
+         // 
+         this.radioDeleteImmediately.AutoSize = true;
+         this.radioDeleteImmediately.Location = new System.Drawing.Point(22, 514);
+         this.radioDeleteImmediately.Name = "radioDeleteImmediately";
+         this.radioDeleteImmediately.Size = new System.Drawing.Size(163, 17);
+         this.radioDeleteImmediately.TabIndex = 45;
+         this.radioDeleteImmediately.Text = "Delete messages immediately";
+         this.radioDeleteImmediately.UseVisualStyleBackColor = true;
+         // 
+         // checkProcessMIMEDate
+         // 
+         this.checkProcessMIMEDate.AutoSize = true;
+         this.checkProcessMIMEDate.Location = new System.Drawing.Point(23, 441);
+         this.checkProcessMIMEDate.Name = "checkProcessMIMEDate";
+         this.checkProcessMIMEDate.Size = new System.Drawing.Size(198, 17);
+         this.checkProcessMIMEDate.TabIndex = 44;
+         this.checkProcessMIMEDate.Text = "Retrieve date from Received header";
+         this.checkProcessMIMEDate.UseVisualStyleBackColor = true;
+         this.checkProcessMIMEDate.CheckedChanged += new System.EventHandler(this.checkProcessMIMEDate_CheckedChanged);
+         // 
+         // checkProcessMIMERecipients
+         // 
+         this.checkProcessMIMERecipients.AutoSize = true;
+         this.checkProcessMIMERecipients.Location = new System.Drawing.Point(23, 395);
+         this.checkProcessMIMERecipients.Name = "checkProcessMIMERecipients";
+         this.checkProcessMIMERecipients.Size = new System.Drawing.Size(205, 17);
+         this.checkProcessMIMERecipients.TabIndex = 43;
+         this.checkProcessMIMERecipients.Text = "Deliver to recipients in MIME headers";
+         this.checkProcessMIMERecipients.UseVisualStyleBackColor = true;
+         this.checkProcessMIMERecipients.CheckedChanged += new System.EventHandler(this.checkProcessMIMERecipients_CheckedChanged);
+         // 
+         // textMinutesBetweenFetch
+         // 
+         this.textMinutesBetweenFetch.Location = new System.Drawing.Point(24, 320);
+         this.textMinutesBetweenFetch.Name = "textMinutesBetweenFetch";
+         this.textMinutesBetweenFetch.Number = 30;
+         this.textMinutesBetweenFetch.Number64 = ((long)(30));
+         this.textMinutesBetweenFetch.Numeric = true;
+         this.textMinutesBetweenFetch.Size = new System.Drawing.Size(146, 20);
+         this.textMinutesBetweenFetch.TabIndex = 42;
+         this.textMinutesBetweenFetch.Text = "30";
+         // 
+         // textUsername
+         // 
+         this.textUsername.Location = new System.Drawing.Point(24, 259);
+         this.textUsername.Name = "textUsername";
+         this.textUsername.Number = 0;
+         this.textUsername.Number64 = ((long)(0));
+         this.textUsername.Numeric = false;
+         this.textUsername.Size = new System.Drawing.Size(148, 20);
+         this.textUsername.TabIndex = 36;
+         // 
+         // textPort
+         // 
+         this.textPort.Location = new System.Drawing.Point(180, 168);
+         this.textPort.Name = "textPort";
+         this.textPort.Number = 0;
+         this.textPort.Number64 = ((long)(0));
+         this.textPort.Numeric = true;
+         this.textPort.Size = new System.Drawing.Size(84, 20);
+         this.textPort.TabIndex = 34;
+         // 
+         // textServer
+         // 
+         this.textServer.Location = new System.Drawing.Point(24, 168);
+         this.textServer.Name = "textServer";
+         this.textServer.Number = 0;
+         this.textServer.Number64 = ((long)(0));
+         this.textServer.Numeric = false;
+         this.textServer.Size = new System.Drawing.Size(148, 20);
+         this.textServer.TabIndex = 32;
+         // 
+         // comboServerType
+         // 
+         this.comboServerType.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+         this.comboServerType.FormattingEnabled = true;
+         this.comboServerType.Location = new System.Drawing.Point(24, 120);
+         this.comboServerType.Name = "comboServerType";
+         this.comboServerType.Size = new System.Drawing.Size(146, 21);
+         this.comboServerType.TabIndex = 20;
+         // 
+         // textName
+         // 
+         this.textName.Location = new System.Drawing.Point(8, 24);
+         this.textName.Name = "textName";
+         this.textName.Number = 0;
+         this.textName.Number64 = ((long)(0));
+         this.textName.Numeric = false;
+         this.textName.Size = new System.Drawing.Size(159, 20);
+         this.textName.TabIndex = 18;
+         // 
+         // checkEnabled
+         // 
+         this.checkEnabled.AutoSize = true;
+         this.checkEnabled.Location = new System.Drawing.Point(8, 50);
+         this.checkEnabled.Name = "checkEnabled";
+         this.checkEnabled.Size = new System.Drawing.Size(65, 17);
+         this.checkEnabled.TabIndex = 14;
+         this.checkEnabled.Text = "Enabled";
+         this.checkEnabled.UseVisualStyleBackColor = true;
+         // 
+         // formExternalAccount
+         // 
+         this.AcceptButton = this.btnOK;
+         this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+         this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+         this.CancelButton = this.btnCancel;
+         this.ClientSize = new System.Drawing.Size(390, 626);
+         this.Controls.Add(this.labelMIMERecipientHeaders);
+         this.Controls.Add(this.textMIMERecipientHeaders);
+         this.Controls.Add(this.labelConnectionSecurity);
+         this.Controls.Add(this.comboConnectionSecurity);
+         this.Controls.Add(this.checkEnableRouteRecipients);
+         this.Controls.Add(this.checkUseAntiSpam);
+         this.Controls.Add(this.checkUseAntiVirus);
+         this.Controls.Add(this.textPassword);
+         this.Controls.Add(this.buttonDownloadNow);
+         this.Controls.Add(this.groupBox1);
+         this.Controls.Add(this.btnCancel);
+         this.Controls.Add(this.btnOK);
+         this.Controls.Add(this.labelDays);
+         this.Controls.Add(this.textDaysToKeepMessages);
+         this.Controls.Add(this.radioNeverDeleteMessages);
+         this.Controls.Add(this.radioDeleteMessagesAfter);
+         this.Controls.Add(this.radioDeleteImmediately);
+         this.Controls.Add(this.checkProcessMIMEDate);
+         this.Controls.Add(this.checkProcessMIMERecipients);
+         this.Controls.Add(this.textMinutesBetweenFetch);
+         this.Controls.Add(this.labelMinutesBetweenDownload);
+         this.Controls.Add(this.labelSettings);
+         this.Controls.Add(this.labelPassword);
+         this.Controls.Add(this.textUsername);
+         this.Controls.Add(this.labelUsername);
+         this.Controls.Add(this.textPort);
+         this.Controls.Add(this.labelTCPIPPort);
+         this.Controls.Add(this.textServer);
+         this.Controls.Add(this.labelServerAddress);
+         this.Controls.Add(this.comboServerType);
+         this.Controls.Add(this.labelServerType);
+         this.Controls.Add(this.textName);
+         this.Controls.Add(this.labelName);
+         this.Controls.Add(this.labelServerInfo);
+         this.Controls.Add(this.checkEnabled);
+         this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+         this.MaximizeBox = false;
+         this.MinimizeBox = false;
+         this.Name = "formExternalAccount";
+         this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+         this.Text = "External account";
+         this.Load += new System.EventHandler(this.formExternalAccount_Load);
+         this.ResumeLayout(false);
+         this.PerformLayout();
 
       }
 
@@ -461,6 +485,8 @@ namespace hMailServer.Administrator.Dialogs
       private System.Windows.Forms.Label labelMinutesBetweenDownload;
       private hMailServer.Administrator.Controls.ucCheckbox checkProcessMIMERecipients;
       private hMailServer.Administrator.Controls.ucCheckbox checkProcessMIMEDate;
+      private hMailServer.Shared.ucText textMIMERecipientHeaders;
+      private System.Windows.Forms.Label labelMIMERecipientHeaders;
       private hMailServer.Administrator.Controls.ucRadioButton radioDeleteImmediately;
       private hMailServer.Administrator.Controls.ucRadioButton radioDeleteMessagesAfter;
       private hMailServer.Administrator.Controls.ucRadioButton radioNeverDeleteMessages;

--- a/hmailserver/source/Tools/Administrator/Dialogs/formExternalAccount.cs
+++ b/hmailserver/source/Tools/Administrator/Dialogs/formExternalAccount.cs
@@ -26,7 +26,8 @@ namespace hMailServer.Administrator.Dialogs
          Strings.Localize(this);
 
          textPort.Number = 110;
-         
+         textMIMERecipientHeaders.Text = "To,CC,X-RCPT-TO,X-Envelope-To";
+
          DirtyChecker.SubscribeToChange(this, OnContentChanged);
          
          buttonDownloadNow.Enabled = false;
@@ -46,7 +47,8 @@ namespace hMailServer.Administrator.Dialogs
       private void EnableDisable()
       {
          btnOK.Enabled = DirtyChecker.IsDirty(this) && textName.Text.Length > 0;
-         checkEnableRouteRecipients.Enabled = checkProcessMIMERecipients.Checked;
+         checkProcessMIMERecipients.Enabled = textMIMERecipientHeaders.Text.Length > 0;
+         checkEnableRouteRecipients.Enabled = checkProcessMIMERecipients.Enabled && checkProcessMIMERecipients.Checked;
       }
 
 
@@ -64,10 +66,10 @@ namespace hMailServer.Administrator.Dialogs
          textPort.Number = fetchAccount.Port;
          textUsername.Text = fetchAccount.Username;
          comboConnectionSecurity.SelectedValue = fetchAccount.ConnectionSecurity;
-         
 
+         textMIMERecipientHeaders.Text = !string.IsNullOrEmpty(fetchAccount.MIMERecipientHeaders) ? fetchAccount.MIMERecipientHeaders : "To,CC,X-RCPT-TO,X-Envelope-To";
          checkProcessMIMERecipients.Checked = fetchAccount.ProcessMIMERecipients;
-         checkProcessMIMEDate.Checked = fetchAccount.ProcessMIMEDate;
+         checkProcessMIMEDate.Checked = fetchAccount.ProcessMIMEDate && !string.IsNullOrEmpty(fetchAccount.MIMERecipientHeaders);
 
          checkUseAntiSpam.Checked = fetchAccount.UseAntiSpam;
          checkUseAntiVirus.Checked = fetchAccount.UseAntiVirus;
@@ -98,15 +100,16 @@ namespace hMailServer.Administrator.Dialogs
          fetchAccount.MinutesBetweenFetch = textMinutesBetweenFetch.Number;
          fetchAccount.Name = textName.Text;
          fetchAccount.Port = textPort.Number;
+         fetchAccount.MIMERecipientHeaders = !string.IsNullOrEmpty(textMIMERecipientHeaders.Text) ? textMIMERecipientHeaders.Text : "To,CC,X-RCPT-TO,X-Envelope-To";
          fetchAccount.ProcessMIMEDate = checkProcessMIMEDate.Checked;
-         fetchAccount.ProcessMIMERecipients = checkProcessMIMERecipients.Checked;
+         fetchAccount.ProcessMIMERecipients = checkProcessMIMERecipients.Checked && checkProcessMIMERecipients.Enabled;
          fetchAccount.ServerAddress = textServer.Text;
-         fetchAccount.ServerType = (int) comboServerType.SelectedValue;
+         fetchAccount.ServerType = (int)comboServerType.SelectedValue;
          fetchAccount.Username = textUsername.Text;
-         fetchAccount.ConnectionSecurity = (eConnectionSecurity) comboConnectionSecurity.SelectedValue;
+         fetchAccount.ConnectionSecurity = (eConnectionSecurity)comboConnectionSecurity.SelectedValue;
          fetchAccount.UseAntiSpam = checkUseAntiSpam.Checked;
          fetchAccount.UseAntiVirus = checkUseAntiVirus.Checked;
-         fetchAccount.EnableRouteRecipients = checkEnableRouteRecipients.Checked;
+         fetchAccount.EnableRouteRecipients = checkEnableRouteRecipients.Checked && checkEnableRouteRecipients.Enabled;
 
          if (textPassword.Dirty)
             fetchAccount.Password = textPassword.Password;
@@ -132,15 +135,15 @@ namespace hMailServer.Administrator.Dialogs
 
       private void buttonDownloadNow_Click(object sender, EventArgs e)
       {
-          // save properties prior to downloading, so we have
-          // the latest settings.
-          if (_fetchAccount != null)
-          {
-              SaveAccountProperties(_fetchAccount);
-              _fetchAccount.Save();
-              _fetchAccount.DownloadNow();
-              this.Close();
-          }
+         // save properties prior to downloading, so we have
+         // the latest settings.
+         if (_fetchAccount != null)
+         {
+            SaveAccountProperties(_fetchAccount);
+            _fetchAccount.Save();
+            _fetchAccount.DownloadNow();
+            this.Close();
+         }
       }
 
       private void checkProcessMIMEDate_CheckedChanged(object sender, EventArgs e)
@@ -158,31 +161,34 @@ namespace hMailServer.Administrator.Dialogs
          EnableDisable();
       }
 
-
+      private void textMIMERecipientHeaders_TextChanged(object sender, EventArgs e)
+      {
+         EnableDisable();
+      }
 
       private void comboConnectionSecurity_SelectedIndexChanged(object sender, EventArgs e)
       {
-          if (_isLoading)
-              return;
+         if (_isLoading)
+            return;
 
-          if ((eConnectionSecurity)comboConnectionSecurity.SelectedValue == eConnectionSecurity.eCSTLS)
-              textPort.Number = 995;
-          else
-              textPort.Number = 110;
+         if ((eConnectionSecurity)comboConnectionSecurity.SelectedValue == eConnectionSecurity.eCSTLS)
+            textPort.Number = 995;
+         else
+            textPort.Number = 110;
 
-          textPort.Font = new Font(this.Font, FontStyle.Bold);
+         textPort.Font = new Font(this.Font, FontStyle.Bold);
 
-          if (_timer != null)
-              _timer.Stop();
+         if (_timer != null)
+            _timer.Stop();
 
-          _timer = new Timer();
-          _timer.Interval = 3000;
-          _timer.Tick += (s, ev) =>
-          {
-              textPort.Font = new Font(this.Font, FontStyle.Regular);
-              _timer.Stop();
-          };
-          _timer.Start();
+         _timer = new Timer();
+         _timer.Interval = 3000;
+         _timer.Tick += (s, ev) =>
+         {
+            textPort.Font = new Font(this.Font, FontStyle.Regular);
+            _timer.Stop();
+         };
+         _timer.Start();
       }
    }
 }

--- a/hmailserver/source/Tools/DBUpdater/formMain.cs
+++ b/hmailserver/source/Tools/DBUpdater/formMain.cs
@@ -165,6 +165,7 @@ namespace DBUpdater
          _upgradeScripts.Add(new UpgradeScript(5601, 5700));
          _upgradeScripts.Add(new UpgradeScript(5700, 5702));
          _upgradeScripts.Add(new UpgradeScript(5702, 5703));
+         _upgradeScripts.Add(new UpgradeScript(5703, 5704));
       }
 
       private void buttonClose_Click(object sender, EventArgs e)
@@ -274,6 +275,8 @@ namespace DBUpdater
                return "hMailServer 5.7 (5702)";
             case 5703:
                return "hMailServer 5.7 (5703)";
+            case 5704:
+               return "hMailServer 5.7 (5704)";
             default:
                return "Unknown version";
          }

--- a/hmailserver/source/WebAdmin/background_account_externalaccount_save.php
+++ b/hmailserver/source/WebAdmin/background_account_externalaccount_save.php
@@ -42,14 +42,21 @@
    $obFA->Name                  = hmailGetVar("Name",0);
    $obFA->MinutesBetweenFetch   = hmailGetVar("MinutesBetweenFetch",0);
    $obFA->Port                  = hmailGetVar("Port",0);
-   $obFA->ProcessMIMERecipients = hmailGetVar("ProcessMIMERecipients",0);
+   $obFA->MIMERecipientHeaders  = hmailGetVar("MIMERecipientHeaders","To,CC,X-RCPT-To,X-Envelope-To");
+   if (strlen($obFA->MIMERecipientHeaders) > 0)
+      $obFA->ProcessMIMERecipients = hmailGetVar("ProcessMIMERecipients",0);
+   else
+      $obFA->ProcessMIMERecipients = 0;
    $obFA->ProcessMIMEDate       = hmailGetVar("ProcessMIMEDate",0);
    $obFA->ServerAddress         = hmailGetVar("ServerAddress",0);
    $obFA->ServerType            = hmailGetVar("ServerType",0);
    $obFA->Username              = hmailGetVar("Username",0);
    $obFA->UseAntiVirus          = hmailGetVar("UseAntiVirus",0);
    $obFA->UseAntiSpam           = hmailGetVar("UseAntiSpam",0);
-   $obFA->EnableRouteRecipients = hmailGetVar("EnableRouteRecipients",0);
+   if ($obFA->ProcessMIMERecipients != 0)
+      $obFA->EnableRouteRecipients = hmailGetVar("EnableRouteRecipients",0);
+   else
+      $obFA->EnableRouteRecipients = 0;
    $obFA->ConnectionSecurity 	= hmailGetVar("ConnectionSecurity",0);
    
    if (strlen($DaysToKeepMessages) > 0 && $DaysToKeepMessages <= 0)

--- a/hmailserver/source/WebAdmin/hm_account_externalaccount.php
+++ b/hmailserver/source/WebAdmin/hm_account_externalaccount.php
@@ -26,6 +26,7 @@ if ($action == "edit")
    $DaysToKeepMessages    = $obFetchAccount->DaysToKeepMessages;
    $MinutesBetweenFetch   = $obFetchAccount->MinutesBetweenFetch;
    $Port  				  = $obFetchAccount->Port;
+   $MIMERecipientHeaders = $obFetchAccount->MIMERecipientHeaders;
    $ProcessMIMERecipients = $obFetchAccount->ProcessMIMERecipients;
    $ProcessMIMEDate       = $obFetchAccount->ProcessMIMEDate;
    $ServerAddress  		  = $obFetchAccount->ServerAddress;
@@ -43,6 +44,7 @@ else
    $DaysToKeepMessages = 0;
    $MinutesBetweenFetch = 30;
    $Port = 110;
+   $MIMERecipientHeaders = "To,CC,X-RCPT-To,X-Envelope-To";
    $ProcessMIMERecipients = 0;
    $ProcessMIMEDate = 0;
    $ServerAddress = "";
@@ -151,7 +153,13 @@ if ($DaysToKeepMessages > 0)
          			<td>
             				<input type="text" name="MinutesBetweenFetch" value="<?php echo PreprocessOutput($MinutesBetweenFetch)?>" checktype="number" checkallownull="false" checkmessage="<?php EchoTranslation("Minutes between download")?>">
                   	</td>			
-         		</tr>			
+         		</tr>		
+         		<tr>
+         			<td><?php EchoTranslation("MIME recipient headers")?></td>
+         			<td>
+            				<input type="text" name="MIMERecipientHeaders" maxlength="255" size="100" value="<?php echo PreprocessOutput($MIMERecipientHeaders)?>" checkallownull="false" checkmessage="<?php EchoTranslation("MIME recipient headers")?>">
+                  	</td>			
+         		</tr>	
          		<tr>
          			<td><?php EchoTranslation("Deliver to recipients in MIME headers")?></td>
          			<td>


### PR DESCRIPTION
Add MIME Recipient Headers as configurable comma delimited array of headers in External download and parse those if enabled.

Gives better flexibility on to which headers to parse, sometimes To and/or CC are desired to be left out, and additional non-rfc headers can be added to this array