### PR TITLE
Harden IMAP folder loading and isolate heavy fetches

### DIFF
--- a/hmailserver/source/Server/Common/Application/Application.cpp
+++ b/hmailserver/source/Server/Common/Application/Application.cpp
@@ -35,6 +35,7 @@
 
 #include "../../SMTP/SMTPDeliveryManager.h"
 #include "../../IMAP/IMAPConfiguration.h"
+#include "../../IMAP/IMAPFetchScheduler.h"
 #include "../../ExternalFetcher/ExternalFetchManager.h"
 
 #include "../Threading/WorkQueueManager.h"
@@ -364,6 +365,7 @@ namespace HM
       if (Configuration::Instance()->GetUseIMAP())
       {
          io_service_->RegisterSessionType(STIMAP);
+         IMAPFetchScheduler::Instance()->Initialize();
       }
    }
 
@@ -420,6 +422,8 @@ namespace HM
       if (external_fetch_manager_) external_fetch_manager_.reset();
       LOG_DEBUG("Application::StopServers() - Destructing Scheduler");
       if (scheduler_) scheduler_.reset();
+
+      IMAPFetchScheduler::Instance()->Shutdown();
       
       LOG_DEBUG("Application::StopServers() - Destructing Rest");
       if (notification_server_) notification_server_.reset();

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.cpp
@@ -25,6 +25,10 @@ namespace HM
       no_of_dbconnection_attempts_(6),
       no_of_dbconnection_attempts_Delay(5),
       max_no_of_external_fetch_threads_(15),
+      enable_imap_fetch_isolation_(false),
+      max_no_of_imap_fetch_tasks_(2),
+      max_no_of_imap_fetch_tasks_per_account_(1),
+      imap_fetch_write_buffer_limit_kb_(4096),
       greylisting_enabled_during_record_expiration_(true),
       greylisting_expiration_interval_(240),
       preferred_hash_algorithm_(3),
@@ -141,6 +145,20 @@ namespace HM
       }
 
       max_no_of_external_fetch_threads_ = ReadIniSettingInteger_("Settings", "MaxNumberOfExternalFetchThreads", 15);
+      enable_imap_fetch_isolation_ = ReadIniSettingInteger_("Settings", "EnableIMAPFetchIsolation", 0) == 1;
+      max_no_of_imap_fetch_tasks_ = ReadIniSettingInteger_("Settings", "MaxNumberOfIMAPFetchTasks", 2);
+      if (max_no_of_imap_fetch_tasks_ < 1)
+         max_no_of_imap_fetch_tasks_ = 1;
+      if (max_no_of_imap_fetch_tasks_ > 100)
+         max_no_of_imap_fetch_tasks_ = 100;
+      max_no_of_imap_fetch_tasks_per_account_ = ReadIniSettingInteger_("Settings", "MaxNumberOfIMAPFetchTasksPerAccount", 1);
+      if (max_no_of_imap_fetch_tasks_per_account_ < 1)
+         max_no_of_imap_fetch_tasks_per_account_ = 1;
+      if (max_no_of_imap_fetch_tasks_per_account_ > 100)
+         max_no_of_imap_fetch_tasks_per_account_ = 100;
+      imap_fetch_write_buffer_limit_kb_ = ReadIniSettingInteger_("Settings", "IMAPFetchWriteBufferLimitKB", 4096);
+      if (imap_fetch_write_buffer_limit_kb_ < 0)
+         imap_fetch_write_buffer_limit_kb_ = 0;
       add_xauth_user_header_ = ReadIniSettingInteger_("Settings", "AddXAuthUserHeader", 0) == 1;
 
       daemonaddress_domain_ = ReadIniSettingString_("Settings", "DaemonAddressDomain", "");

--- a/hmailserver/source/Server/Common/Application/IniFileSettings.h
+++ b/hmailserver/source/Server/Common/Application/IniFileSettings.h
@@ -74,6 +74,10 @@ namespace HM
       String GetDaemonAddressDomain() const { return daemonaddress_domain_; }
       bool GetAddXOriginalRcptToHeader() { return add_xoriginal_rcpt_to_header_; }	  
       int GetMaxNumberOfExternalFetchThreads() {return max_no_of_external_fetch_threads_ ;}
+      bool GetEnableIMAPFetchIsolation() const { return enable_imap_fetch_isolation_; }
+      int GetMaxNumberOfIMAPFetchTasks() const { return max_no_of_imap_fetch_tasks_; }
+      int GetMaxNumberOfIMAPFetchTasksPerAccount() const { return max_no_of_imap_fetch_tasks_per_account_; }
+      int GetIMAPFetchWriteBufferLimitKB() const { return imap_fetch_write_buffer_limit_kb_; }
       bool GetGreylistingEnabledDuringRecordExpiration() {return greylisting_enabled_during_record_expiration_;}
       int GetGreylistingExpirationInterval() {return greylisting_expiration_interval_; }
       int GetPreferredHashAlgorithm() {return preferred_hash_algorithm_;}
@@ -151,6 +155,10 @@ namespace HM
       String daemonaddress_domain_;
       bool add_xoriginal_rcpt_to_header_;	  
       int max_no_of_external_fetch_threads_;
+      bool enable_imap_fetch_isolation_;
+      int max_no_of_imap_fetch_tasks_;
+      int max_no_of_imap_fetch_tasks_per_account_;
+      int imap_fetch_write_buffer_limit_kb_;
 
       bool greylisting_enabled_during_record_expiration_;
       bool is_internal_database_;

--- a/hmailserver/source/Server/Common/BO/IMAPFolders.cpp
+++ b/hmailserver/source/Server/Common/BO/IMAPFolders.cpp
@@ -55,6 +55,8 @@ namespace HM
          return;
 
       std::vector<std::pair<__int64, std::shared_ptr<IMAPFolder> > > vecIMAPFolders;
+      std::map<__int64, std::shared_ptr<IMAPFolder> > foldersByID;
+      std::map<__int64, __int64> parentByID;
 
       if (!pRS->IsEOF())
       {
@@ -86,62 +88,140 @@ namespace HM
             pFolder->SetCreationTime(creationTime);
 
             vecIMAPFolders.push_back(std::make_pair(iParentID, pFolder));
+            foldersByID[iFolderID] = pFolder;
+            parentByID[iFolderID] = iParentID;
 
             pRS->MoveNext();
          }
 
-         // Sort theese folders into sub-folders.
-         long lPanicLevel = 0;
-         while (vecIMAPFolders.size() > 0)
+         __int64 inboxFolderID = -1;
+         for (auto folder : vecIMAPFolders)
          {
-            auto iterFolder = vecIMAPFolders.begin();
-
-            while (iterFolder != vecIMAPFolders.end())
+            std::shared_ptr<IMAPFolder> pFolder = folder.second;
+            if (pFolder->GetFolderName().CompareNoCase(_T("INBOX")) == 0)
             {
-               __int64 iFolderParentID = (*iterFolder).first;
-
-               if (iFolderParentID == (__int64) -1)
+               if (folder.first == -1)
                {
-                  vecObjects.push_back((*iterFolder).second);
-                  vecIMAPFolders.erase(iterFolder);
-                  
-                  break; 
-               }
-               else
-               {
-                  std::shared_ptr<IMAPFolder> pParent = GetItemByDBIDRecursive(iFolderParentID);
-
-                  if (pParent)
-                  {
-                     pParent->GetSubFolders()->AddItem((*iterFolder).second); // found
-                     vecIMAPFolders.erase(iterFolder);
-                     break;
-                  }
+                  inboxFolderID = pFolder->GetID();
+                  break;
                }
 
-               iterFolder++;
-            }  
-
-            lPanicLevel++;
-
-            if (lPanicLevel > 100000)
-            {
-               String sMessage;
-			   // NEED FOR IMPROVEMENT: User should be able to adjust max even if INI
-			   // User in forum had too many folders & this limit caused big issues
-			   // 
-			   // Better logging details so people understand what happened until fixed/adjustable
-			   sMessage.Format(_T("Unable to retrieve folder list for account. 100K+ loops trying to sort. Account: %I64d, Parent: %I64d"), account_id_, parent_folder_id_);
-               
-               ErrorManager::Instance()->ReportError(
-                  ErrorManager::Medium, 5125, "IMAPFolders::Refresh()", sMessage);       
-
-               return;
+               if (inboxFolderID == -1)
+                  inboxFolderID = pFolder->GetID();
             }
-
          }
 
-      
+         std::set<__int64> repairedFolderIDs;
+         for (auto folder : vecIMAPFolders)
+         {
+            std::shared_ptr<IMAPFolder> pFolder = folder.second;
+            __int64 folderID = pFolder->GetID();
+            __int64 parentID = parentByID[folderID];
+
+            if (parentID == 0)
+            {
+               if (inboxFolderID > 0 && inboxFolderID != folderID)
+                  parentID = inboxFolderID;
+               else
+                  parentID = -1;
+
+               parentByID[folderID] = parentID;
+               repairedFolderIDs.insert(folderID);
+            }
+
+            if (parentID == folderID)
+            {
+               parentByID[folderID] = -1;
+               repairedFolderIDs.insert(folderID);
+               continue;
+            }
+
+            if (parentID != -1 && foldersByID.find(parentID) == foldersByID.end())
+            {
+               parentByID[folderID] = -1;
+               repairedFolderIDs.insert(folderID);
+               continue;
+            }
+         }
+
+         std::map<__int64, int> folderVisitState;
+         for (auto folder : vecIMAPFolders)
+         {
+            std::shared_ptr<IMAPFolder> pFolder = folder.second;
+            __int64 folderID = pFolder->GetID();
+
+            std::vector<__int64> visitedFolderIDs;
+            __int64 currentFolderID = folderID;
+            while (currentFolderID != -1)
+            {
+               if (folderVisitState[currentFolderID] == 2)
+                  break;
+
+               if (folderVisitState[currentFolderID] == 1)
+               {
+                  parentByID[folderID] = -1;
+                  repairedFolderIDs.insert(folderID);
+                  break;
+               }
+
+               folderVisitState[currentFolderID] = 1;
+               visitedFolderIDs.push_back(currentFolderID);
+
+               auto iterParent = parentByID.find(currentFolderID);
+               if (iterParent == parentByID.end() || iterParent->second == currentFolderID)
+               {
+                  parentByID[folderID] = -1;
+                  repairedFolderIDs.insert(folderID);
+                  break;
+               }
+
+               currentFolderID = iterParent->second;
+            }
+
+            for (__int64 visitedFolderID : visitedFolderIDs)
+               folderVisitState[visitedFolderID] = 2;
+         }
+
+         for (auto folder : vecIMAPFolders)
+         {
+            std::shared_ptr<IMAPFolder> pFolder = folder.second;
+            __int64 folderID = pFolder->GetID();
+            __int64 parentID = parentByID[folderID];
+
+            pFolder->SetParentFolderID(parentID);
+
+            if (parentID == -1)
+            {
+               vecObjects.push_back(pFolder);
+               continue;
+            }
+
+            auto iterParent = foldersByID.find(parentID);
+            if (iterParent != foldersByID.end())
+               iterParent->second->GetSubFolders()->AddItem(pFolder);
+            else
+               vecObjects.push_back(pFolder);
+         }
+
+         if (repairedFolderIDs.size() > 0)
+         {
+            String repairedFolders;
+            bool addSeparator = false;
+            for (__int64 folderID : repairedFolderIDs)
+            {
+               if (addSeparator)
+                  repairedFolders += ", ";
+
+               repairedFolders += StringParser::IntToString(folderID);
+               addSeparator = true;
+            }
+
+            String sMessage;
+            sMessage.Format(_T("Malformed IMAP folder parent references were repaired in memory. Account: %I64d, Folders: %s"), account_id_, repairedFolders.c_str());
+
+            ErrorManager::Instance()->ReportError(
+               ErrorManager::Medium, 5125, "IMAPFolders::Refresh()", sMessage);
+         }
       }
 
    }
@@ -365,4 +445,3 @@ namespace HM
          return false;
    }
 }
-

--- a/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.cpp
@@ -5,6 +5,7 @@
 #include "StdAfx.h"
 #include "IOOperationQueue.h"
 #include "IOOperation.h"
+#include "../Util/ByteBuffer.h"
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -76,6 +77,27 @@ namespace HM
       }
 
       return false;
+   }
+
+   size_t
+   IOOperationQueue::GetPendingWriteBytes()
+   {
+      boost::lock_guard<boost::recursive_mutex> guard(mutex_);
+
+      size_t bytes = 0;
+      for (std::shared_ptr<IOOperation> operation : queue_operations_)
+      {
+         if (operation->GetType() == IOOperation::BCTWrite && operation->GetBuffer())
+            bytes += operation->GetBuffer()->GetSize();
+      }
+
+      for (std::shared_ptr<IOOperation> operation : ongoing_operations_)
+      {
+         if (operation->GetType() == IOOperation::BCTWrite && operation->GetBuffer())
+            bytes += operation->GetBuffer()->GetSize();
+      }
+
+      return bytes;
    }
 
    std::shared_ptr<IOOperation>

--- a/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.h
+++ b/hmailserver/source/Server/Common/TCPIP/IOOperationQueue.h
@@ -20,6 +20,7 @@ namespace HM
       void Pop(IOOperation::OperationType type);
 
       bool ContainsQueuedSendOperation();
+      size_t GetPendingWriteBytes();
 
    private:
 

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.cpp
@@ -620,6 +620,12 @@ namespace HM
       ProcessOperationQueue_(0);
    }
 
+   size_t
+   TCPConnection::GetPendingWriteBytes()
+   {
+      return operation_queue_.GetPendingWriteBytes();
+   }
+
    void 
    TCPConnection::AsyncWrite(std::shared_ptr<ByteBuffer> buffer)
    {

--- a/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
+++ b/hmailserver/source/Server/Common/TCPIP/TCPConnection.h
@@ -49,6 +49,7 @@ namespace HM
       void EnqueueShutdownSend();
       void EnqueueDisconnect();
       void EnqueueHandshake();
+      size_t GetPendingWriteBytes();
       
       IPAddress GetRemoteEndpointAddress();
       unsigned long GetLocalEndpointPort();

--- a/hmailserver/source/Server/IMAP/IMAPCommandFetch.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandFetch.cpp
@@ -4,7 +4,9 @@
 #include "stdafx.h"
 #include "IMAPCommandFetch.h"
 #include "IMAPFetch.h"
+#include "IMAPFetchScheduler.h"
 #include "IMAPConnection.h"
+#include "../Common/BO/Account.h"
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -54,6 +56,31 @@ namespace HM
 
       if (!StringParser::ValidateString(sMailNo, "01234567890,.:*"))
          return IMAPResult(IMAPResult::ResultBad, "Incorrect mail number");
+
+      if (IMAPFetchScheduler::Instance()->GetEnabled() && IMAPFetchScheduler::Instance()->IsHeavyFetch(sShowPart))
+      {
+         __int64 accountID = pConnection->GetAccount()->GetID();
+         bool queued = IMAPFetchScheduler::Instance()->QueueFetch(
+            accountID,
+            [pFetch, pConnection, sMailNo, pArgument]() -> IMAPResult
+            {
+               return pFetch->DoForMails(pConnection, sMailNo, pArgument);
+            },
+            [pConnection, pArgument](IMAPResult result)
+            {
+               if (result.GetResult() == IMAPResult::ResultOK)
+                  pConnection->SendAsciiData(pArgument->Tag() + " OK FETCH completed\r\n");
+               else if (result.GetResult() == IMAPResult::ResultBad)
+                  pConnection->SendAsciiData(pArgument->Tag() + " BAD " + result.GetMessage() + "\r\n");
+               else if (result.GetResult() == IMAPResult::ResultNo)
+                  pConnection->SendAsciiData(pArgument->Tag() + " NO " + result.GetMessage() + "\r\n");
+
+               pConnection->EnqueueRead();
+            });
+
+         if (queued)
+            return IMAPResult(IMAPResult::ResultOKSupressRead, "");
+      }
       
       IMAPResult result = pFetch->DoForMails(pConnection, sMailNo, pArgument);
 

--- a/hmailserver/source/Server/IMAP/IMAPCommandUID.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPCommandUID.cpp
@@ -8,9 +8,11 @@
 
 
 #include "IMAPFetch.h"
+#include "IMAPFetchScheduler.h"
 #include "IMAPCopy.h"
 #include "IMAPStore.h"
 #include "IMAPCommandSearch.h"
+#include "../Common/BO/Account.h"
 
 #ifdef _DEBUG
 #define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -122,6 +124,34 @@ namespace HM
 
       // Execute the command. If we have gotten this far, it means that the syntax
       // of the command is correct. If we fail now, we should return NO. 
+      if (sTypeOfUID.CompareNoCase(_T("FETCH")) == 0 &&
+          IMAPFetchScheduler::Instance()->GetEnabled() &&
+          IMAPFetchScheduler::Instance()->IsHeavyFetch(sShowPart))
+      {
+         __int64 accountID = pConnection->GetAccount()->GetID();
+         std::shared_ptr<IMAPCommandRangeAction> command = command_;
+         bool queued = IMAPFetchScheduler::Instance()->QueueFetch(
+            accountID,
+            [command, pConnection, sMailNo, pArgument]() -> IMAPResult
+            {
+               return command->DoForMails(pConnection, sMailNo, pArgument);
+            },
+            [pConnection, pArgument](IMAPResult result)
+            {
+               if (result.GetResult() == IMAPResult::ResultOK)
+                  pConnection->SendAsciiData(pArgument->Tag() + " OK UID completed\r\n");
+               else if (result.GetResult() == IMAPResult::ResultBad)
+                  pConnection->SendAsciiData(pArgument->Tag() + " BAD " + result.GetMessage() + "\r\n");
+               else if (result.GetResult() == IMAPResult::ResultNo)
+                  pConnection->SendAsciiData(pArgument->Tag() + " NO " + result.GetMessage() + "\r\n");
+
+               pConnection->EnqueueRead();
+            });
+
+         if (queued)
+            return IMAPResult(IMAPResult::ResultOKSupressRead, "");
+      }
+
       IMAPResult result = command_->DoForMails(pConnection, sMailNo, pArgument);
 
       if (result.GetResult() == IMAPResult::ResultOK)

--- a/hmailserver/source/Server/IMAP/IMAPFetch.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPFetch.cpp
@@ -7,6 +7,7 @@
 #include "IMAPConnection.h"
 
 #include "../Common/Application/FolderManager.h"
+#include "../Common/Application/IniFileSettings.h"
 #include "../Common/BO/IMAPFolder.h"
 #include "../Common/BO/Message.h"
 #include "../Common/Util/Charset.h"
@@ -213,6 +214,18 @@ namespace HM
 
                // Send the actual part
                pConnection->EnqueueWrite(pBuffer);
+
+               int writeBufferLimitKB = IniFileSettings::Instance()->GetIMAPFetchWriteBufferLimitKB();
+               if (IniFileSettings::Instance()->GetEnableIMAPFetchIsolation() && writeBufferLimitKB > 0)
+               {
+                  size_t writeBufferLimitBytes = (size_t) writeBufferLimitKB * 1024;
+                  int waitCount = 0;
+                  while (pConnection->GetPendingWriteBytes() > writeBufferLimitBytes && waitCount < 1200)
+                  {
+                     Sleep(25);
+                     waitCount++;
+                  }
+               }
             }
             else
             {
@@ -1190,4 +1203,3 @@ namespace HM
    }
 
 }
-

--- a/hmailserver/source/Server/IMAP/IMAPFetchScheduler.cpp
+++ b/hmailserver/source/Server/IMAP/IMAPFetchScheduler.cpp
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 hMailServer contributors
+
+#include "stdafx.h"
+
+#include "IMAPFetchScheduler.h"
+#include "IMAPFetchParser.h"
+
+#include "../Common/Application/IniFileSettings.h"
+#include "../Common/Threading/WorkQueueManager.h"
+
+#ifdef _DEBUG
+#define DEBUG_NEW new(_NORMAL_BLOCK, __FILE__, __LINE__)
+#define new DEBUG_NEW
+#endif
+
+namespace HM
+{
+   IMAPFetchTask::IMAPFetchTask(__int64 accountID, std::function<IMAPResult()> fetchFunction, std::function<void(IMAPResult)> completionFunction) :
+      Task("IMAPFetchTask"),
+      account_id_(accountID),
+      fetch_function_(fetchFunction),
+      completion_function_(completionFunction)
+   {
+
+   }
+
+   IMAPFetchTask::~IMAPFetchTask()
+   {
+
+   }
+
+   void
+   IMAPFetchTask::DoWork()
+   {
+      IMAPResult result(IMAPResult::ResultNo, "IMAP FETCH failed");
+
+      try
+      {
+         result = fetch_function_();
+      }
+      catch (...)
+      {
+         result = IMAPResult(IMAPResult::ResultNo, "IMAP FETCH failed");
+      }
+
+      try
+      {
+         completion_function_(result);
+      }
+      catch (...)
+      {
+      }
+
+      IMAPFetchScheduler::Instance()->OnTaskCompleted(account_id_);
+   }
+
+   IMAPFetchScheduler::IMAPFetchScheduler() :
+      initialized_(false),
+      queue_id_(0),
+      queue_name_("IMAP fetch queue"),
+      running_task_count_(0)
+   {
+
+   }
+
+   IMAPFetchScheduler::~IMAPFetchScheduler()
+   {
+
+   }
+
+   void
+   IMAPFetchScheduler::Initialize()
+   {
+      boost::lock_guard<boost::recursive_mutex> guard(mutex_);
+
+      if (initialized_)
+         return;
+
+      if (!GetEnabled())
+      {
+         LOG_APPLICATION("IMAP fetch isolation is disabled. Legacy inline FETCH handling is active.")
+         return;
+      }
+
+      int maxTasks = IniFileSettings::Instance()->GetMaxNumberOfIMAPFetchTasks();
+      queue_id_ = WorkQueueManager::Instance()->CreateWorkQueue(maxTasks, queue_name_);
+      initialized_ = true;
+
+      String message;
+      message.Format(_T("IMAP fetch isolation is enabled. MaxNumberOfIMAPFetchTasks=%d, MaxNumberOfIMAPFetchTasksPerAccount=%d, IMAPFetchWriteBufferLimitKB=%d"),
+         maxTasks,
+         IniFileSettings::Instance()->GetMaxNumberOfIMAPFetchTasksPerAccount(),
+         IniFileSettings::Instance()->GetIMAPFetchWriteBufferLimitKB());
+      LOG_APPLICATION(message)
+   }
+
+   void
+   IMAPFetchScheduler::Shutdown()
+   {
+      bool removeQueue = false;
+
+      {
+         boost::lock_guard<boost::recursive_mutex> guard(mutex_);
+
+         pending_tasks_.clear();
+         running_tasks_by_account_.clear();
+         running_task_count_ = 0;
+
+         if (!initialized_)
+            return;
+
+         initialized_ = false;
+         queue_id_ = 0;
+         removeQueue = true;
+      }
+
+      if (removeQueue)
+         WorkQueueManager::Instance()->RemoveQueue(queue_name_);
+   }
+
+   bool
+   IMAPFetchScheduler::GetEnabled() const
+   {
+      return IniFileSettings::Instance()->GetEnableIMAPFetchIsolation();
+   }
+
+   bool
+   IMAPFetchScheduler::IsHeavyFetch(const String &command) const
+   {
+      IMAPFetchParser parser;
+      IMAPResult parseResult = parser.ParseCommand(command);
+      if (parseResult.GetResult() != IMAPResult::ResultOK)
+         return false;
+
+      return parser.GetShowEnvelope() ||
+             parser.GetShowBodyStructure() ||
+             parser.GetShowBodyStructureNonExtensible() ||
+             parser.GetPartsToLookAt().size() > 0;
+   }
+
+   bool
+   IMAPFetchScheduler::QueueFetch(__int64 accountID, std::function<IMAPResult()> fetchFunction, std::function<void(IMAPResult)> completionFunction)
+   {
+      boost::lock_guard<boost::recursive_mutex> guard(mutex_);
+
+      if (!initialized_)
+         return false;
+
+      std::shared_ptr<IMAPFetchTask> task = std::shared_ptr<IMAPFetchTask>(new IMAPFetchTask(accountID, fetchFunction, completionFunction));
+      pending_tasks_.push_back(task);
+      StartQueuedTasks_();
+
+      return true;
+   }
+
+   void
+   IMAPFetchScheduler::OnTaskCompleted(__int64 accountID)
+   {
+      boost::lock_guard<boost::recursive_mutex> guard(mutex_);
+
+      if (running_task_count_ > 0)
+         running_task_count_--;
+
+      auto iterAccount = running_tasks_by_account_.find(accountID);
+      if (iterAccount != running_tasks_by_account_.end())
+      {
+         iterAccount->second--;
+         if (iterAccount->second <= 0)
+            running_tasks_by_account_.erase(iterAccount);
+      }
+
+      StartQueuedTasks_();
+   }
+
+   void
+   IMAPFetchScheduler::StartQueuedTasks_()
+   {
+      if (!initialized_)
+         return;
+
+      auto iterTask = pending_tasks_.begin();
+      while (iterTask != pending_tasks_.end())
+      {
+         std::shared_ptr<IMAPFetchTask> task = (*iterTask);
+         if (!CanStartTask_(task))
+         {
+            iterTask++;
+            continue;
+         }
+
+         running_task_count_++;
+         running_tasks_by_account_[task->GetAccountID()]++;
+
+         WorkQueueManager::Instance()->AddTask(queue_id_, task);
+         iterTask = pending_tasks_.erase(iterTask);
+      }
+   }
+
+   bool
+   IMAPFetchScheduler::CanStartTask_(std::shared_ptr<IMAPFetchTask> task) const
+   {
+      int maxTasks = IniFileSettings::Instance()->GetMaxNumberOfIMAPFetchTasks();
+      if (running_task_count_ >= maxTasks)
+         return false;
+
+      int accountTaskCount = 0;
+      auto iterAccount = running_tasks_by_account_.find(task->GetAccountID());
+      if (iterAccount != running_tasks_by_account_.end())
+         accountTaskCount = iterAccount->second;
+
+      return accountTaskCount < IniFileSettings::Instance()->GetMaxNumberOfIMAPFetchTasksPerAccount();
+   }
+}

--- a/hmailserver/source/Server/IMAP/IMAPFetchScheduler.h
+++ b/hmailserver/source/Server/IMAP/IMAPFetchScheduler.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 hMailServer contributors
+
+#pragma once
+
+#include <deque>
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "IMAPResult.h"
+#include "../Common/Threading/Task.h"
+
+namespace HM
+{
+   class IMAPConnection;
+   class IMAPCommandArgument;
+
+   class IMAPFetchTask : public Task
+   {
+   public:
+      IMAPFetchTask(__int64 accountID, std::function<IMAPResult()> fetchFunction, std::function<void(IMAPResult)> completionFunction);
+      virtual ~IMAPFetchTask();
+
+      __int64 GetAccountID() const { return account_id_; }
+
+   protected:
+      virtual void DoWork();
+
+   private:
+      __int64 account_id_;
+      std::function<IMAPResult()> fetch_function_;
+      std::function<void(IMAPResult)> completion_function_;
+   };
+
+   class IMAPFetchScheduler : public Singleton<IMAPFetchScheduler>
+   {
+   public:
+      IMAPFetchScheduler();
+      virtual ~IMAPFetchScheduler();
+
+      void Initialize();
+      void Shutdown();
+
+      bool GetEnabled() const;
+      bool IsHeavyFetch(const String &command) const;
+
+      bool QueueFetch(__int64 accountID, std::function<IMAPResult()> fetchFunction, std::function<void(IMAPResult)> completionFunction);
+      void OnTaskCompleted(__int64 accountID);
+
+   private:
+      void StartQueuedTasks_();
+      bool CanStartTask_(std::shared_ptr<IMAPFetchTask> task) const;
+
+      bool initialized_;
+      size_t queue_id_;
+      String queue_name_;
+
+      std::deque<std::shared_ptr<IMAPFetchTask> > pending_tasks_;
+      std::map<__int64, int> running_tasks_by_account_;
+      int running_task_count_;
+
+      boost::recursive_mutex mutex_;
+   };
+}

--- a/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
+++ b/hmailserver/source/Server/hMailServer/hMailServer.vcxproj
@@ -594,6 +594,7 @@ EXIT 0
     <ClCompile Include="..\Imap\IMAPCopy.cpp" />
     <ClCompile Include="..\Imap\IMAPFetch.cpp" />
     <ClCompile Include="..\Imap\IMAPFetchParser.cpp" />
+    <ClCompile Include="..\IMAP\IMAPFetchScheduler.cpp" />
     <ClCompile Include="..\IMAP\IMAPFolderContainer.cpp" />
     <ClCompile Include="..\IMAP\IMAPFolderUtilities.cpp" />
     <ClCompile Include="..\IMAP\IMAPListLookup.cpp" />
@@ -1095,6 +1096,7 @@ EXIT 0
     <ClInclude Include="..\Imap\IMAPCopy.h" />
     <ClInclude Include="..\Imap\IMAPFetch.h" />
     <ClInclude Include="..\Imap\IMAPFetchParser.h" />
+    <ClInclude Include="..\IMAP\IMAPFetchScheduler.h" />
     <ClInclude Include="..\IMAP\IMAPFolderContainer.h" />
     <ClInclude Include="..\IMAP\IMAPFolderUtilities.h" />
     <ClInclude Include="..\IMAP\IMAPListLookup.h" />


### PR DESCRIPTION
This change addresses two IMAP stability issues:
- Replace recursive IMAP folder sorting with a map-based tree build that repairs malformed parent references in memory.
- Add opt-in IMAP FETCH isolation with configurable global/per-account limits and write-queue backpressure so aggressive clients on slow storage cannot monopolize TCP/IP workers by default.

## IMAP Folder Loading

The IMAP folder refresh logic no longer repeatedly searches recursively while trying to attach child folders.

Instead, folders are loaded once into an ID map and assembled into a tree from that map.

Malformed folder parents are repaired in memory only:

- `folderparentid = 0` is treated as legacy data and attached under the account `INBOX` when possible.
- If `INBOX` is missing, or the folder itself is `INBOX`, the folder is promoted to root.
- Missing parents are promoted to root.
- Self-parenting folders are promoted to root.
- Cycles are detected and broken by promoting the affected folder to root.

No database rows are modified during refresh. Repairs are logged with account/folder IDs.

## IMAP FETCH Isolation

Legacy behavior remains the default.

By default:

```ini
EnableIMAPFetchIsolation=0
```
When disabled, FETCH continues to run inline on the TCP/IP command thread exactly as before.

When enabled:
```ini
EnableIMAPFetchIsolation=1
```
heavy IMAP FETCH and UID FETCH commands are moved to a dedicated fetch scheduler instead of running directly on IOCP/TCP command threads.

This is intended for deployments where slow/shared mail storage, such as SMB/Samba, can cause aggressive IMAP clients to monopolize server command threads.

### New INI Settings
```ini
[Settings]
EnableIMAPFetchIsolation=0
MaxNumberOfIMAPFetchTasks=2
MaxNumberOfIMAPFetchTasksPerAccount=1
IMAPFetchWriteBufferLimitKB=4096
```

#### EnableIMAPFetchIsolation
Default: 0
Controls whether the new fetch isolation path is active.

0: legacy inline behavior
1: heavy fetches are scheduled through the isolated IMAP fetch queue

#### MaxNumberOfIMAPFetchTasks
Default: 2
Maximum number of heavy IMAP fetch tasks allowed to run globally.

This prevents IMAP downloads from occupying too many worker threads at once.

#### MaxNumberOfIMAPFetchTasksPerAccount
Default: 1

Maximum number of heavy IMAP fetch tasks allowed per account.

This prevents one large mailbox/client from starving other users.

#### IMAPFetchWriteBufferLimitKB
Default: 4096

Soft write-queue backpressure limit for isolated fetches.

When a fetch response queues more than this amount of pending socket output, the fetch worker pauses briefly before reading/enqueueing more message data.

This reduces the chance of a broad mailbox download opening/reading many .eml files faster than the client can receive them.

### What Counts As A Heavy Fetch
The isolation path is used only for fetches that need to touch message files or parse MIME content, including:
BODY[...]
BODY.PEEK[...]
BODYSTRUCTURE
RFC822
RFC822.HEADER
RFC822.TEXT
ENVELOPE
macros that imply file/header work, such as ALL and FULL.

Cheap metadata fetches remain inline, including:
UID
FLAGS
RFC822.SIZE
INTERNALDATE
FAST

### Verification
None. Windows build/tests were not run. I don't have the environment to run test.
But if compiled with installer RvdHout, I can deploy it to test.